### PR TITLE
Change Template path so that it conforms to the path in S3

### DIFF
--- a/src/main/scala/uk/gov/hmrc/renderer/MustachRenderer.scala
+++ b/src/main/scala/uk/gov/hmrc/renderer/MustachRenderer.scala
@@ -66,5 +66,5 @@ trait MustacheRendererTrait {
     Html(templateEngine.layout("outPut.ssp", tpl, attributes))
   }
 
-  def renderDefaultTemplate = renderTemplate("/frontend-template-provider/serve-template") _
+  def renderDefaultTemplate = renderTemplate("/template/mustache") _
 }


### PR DESCRIPTION
we needed to change the template path so that we could piggy-back on the existing S3 bucket and /template path that is already setup.